### PR TITLE
Use path.resolve for resolving filepaths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,12 @@ const loadCredentials = require("./load-credentials");
 const goEncrypt = require("./go-encrypt");
 const fs = require("fs");
 const yaml = require("js-yaml");
+const path = require("path");
 const { version } = require("../package.json");
 
 function readFile(file) {
     return new Promise((resolve, reject) => {
-        fs.readFile(`${process.cwd()}/${file}`, "utf-8", (err, data) => {
+        fs.readFile(path.resolve(file), "utf-8", (err, data) => {
             if(err) {
                 return reject(err);
             }


### PR DESCRIPTION
The previous implementation only allows encrypting files under the current working directory.